### PR TITLE
add support for s3 compatible servers + test with minio

### DIFF
--- a/datapackage_pipelines_aws/s3_dumper.py
+++ b/datapackage_pipelines_aws/s3_dumper.py
@@ -1,4 +1,5 @@
-import boto3, os
+import boto3
+import os
 from datapackage_pipelines.lib.dump.dumper_base import FileDumper
 
 from datapackage_pipelines_aws.helpers import generate_path
@@ -10,7 +11,8 @@ class S3Dumper(FileDumper):
         super(S3Dumper, self).initialize(params)
         self.bucket = params['bucket']
         self.acl = params.get('acl', 'public-read')
-        self.client = boto3.client('s3', endpoint_url=os.environ.get("S3_ENDPOINT_URL"))
+        endpoint_url = os.environ.get("S3_ENDPOINT_URL")
+        self.client = boto3.client('s3', endpoint_url=endpoint_url)
         self.base_path = params.get('path', '')
         self.content_type = params.get('content_type', 'text/plain')
 
@@ -30,9 +32,11 @@ class S3Dumper(FileDumper):
                 Key=key)
         except self.client.exceptions.NoSuchBucket:
             if os.environ.get("S3_ENDPOINT_URL") and allow_create_bucket:
-                # if you provided a custom endpoint url, we assume you are using a s3 compatible server
-                # in this case, creating a bucket should be cheap and easy, so we can do it here
+                # if you provided a custom endpoint url, we assume you are
+                # using an s3 compatible server, in this case, creating a
+                # bucket should be cheap and easy, so we can do it here
                 self.client.create_bucket(Bucket=self.bucket)
-                self.write_file_to_output(filename, path, allow_create_bucket=False)
+                self.write_file_to_output(filename, path,
+                                          allow_create_bucket=False)
             else:
                 raise

--- a/datapackage_pipelines_aws/s3_dumper.py
+++ b/datapackage_pipelines_aws/s3_dumper.py
@@ -1,4 +1,4 @@
-import boto3
+import boto3, os
 from datapackage_pipelines.lib.dump.dumper_base import FileDumper
 
 from datapackage_pipelines_aws.helpers import generate_path
@@ -10,7 +10,7 @@ class S3Dumper(FileDumper):
         super(S3Dumper, self).initialize(params)
         self.bucket = params['bucket']
         self.acl = params.get('acl', 'public-read')
-        self.client = boto3.client('s3')
+        self.client = boto3.client('s3', endpoint_url=os.environ.get("S3_ENDPOINT_URL"))
         self.base_path = params.get('path', '')
         self.content_type = params.get('content_type', 'text/plain')
 
@@ -19,11 +19,20 @@ class S3Dumper(FileDumper):
         self.datapackage = datapackage
         return datapackage
 
-    def write_file_to_output(self, filename, path):
+    def write_file_to_output(self, filename, path, allow_create_bucket=True):
         key = generate_path(path, self.base_path, self.datapackage)
-        self.client.put_object(
-            ACL=self.acl,
-            Body=open(filename, 'rb'),
-            Bucket=self.bucket,
-            ContentType=self.content_type,
-            Key=key)
+        try:
+            self.client.put_object(
+                ACL=self.acl,
+                Body=open(filename, 'rb'),
+                Bucket=self.bucket,
+                ContentType=self.content_type,
+                Key=key)
+        except self.client.exceptions.NoSuchBucket:
+            if os.environ.get("S3_ENDPOINT_URL") and allow_create_bucket:
+                # if you provided a custom endpoint url, we assume you are using a s3 compatible server
+                # in this case, creating a bucket should be cheap and easy, so we can do it here
+                self.client.create_bucket(Bucket=self.bucket)
+                self.write_file_to_output(filename, path, allow_create_bucket=False)
+            else:
+                raise

--- a/tests/minio/noise.py
+++ b/tests/minio/noise.py
@@ -1,0 +1,29 @@
+from datapackage_pipelines.wrapper import spew, ingest
+from datapackage_pipelines.utilities.resources import PROP_STREAMING
+
+
+def get_resource(i):
+    for j in range(10000):
+        yield {"i": i, "j": j}
+
+
+def get_resources():
+    for i in range(5):
+        yield get_resource(i)
+
+
+def get_resource_descriptors():
+    for i in range(5):
+        yield {"name": "noise{}".format(i),
+               "schema": {"fields": [{"name": "i", "type": "number"},
+                                     {"name": "j", "type": "number"}]},
+               "path": "noise{}.csv".format(i),
+               PROP_STREAMING: True,}
+
+
+def get_datapackage():
+    return {"name": "noise", "resources": list(get_resource_descriptors())}
+
+
+parameters, datapackage, resources = ingest()
+spew(get_datapackage(), get_resources())

--- a/tests/minio/test_minio.sh
+++ b/tests/minio/test_minio.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+export AWS_ACCESS_KEY_ID="HJW6280KHBS2Y105STGG"
+export AWS_SECRET_ACCESS_KEY="rsAuRptRwTTuSocsdBCRHIToldPkPefpb2Vl/ybG"
+export S3_ENDPOINT_URL="http://localhost:9000"
+
+if [ ! -d tests/minio ]; then
+    echo "This script should run from the project root directory"
+    exit 1
+fi
+
+echo "noise:
+  pipeline:
+  - run: noise
+  - run: aws.dump.to_s3
+    parameters:
+      bucket: noise" > tests/minio/pipeline-spec.yaml
+
+# start the pipeline before starting the server to check the retry mechanism
+dpp run ./tests/minio/noise &
+
+sleep 2
+
+docker run -p9000:9000 \
+    --rm \
+    --name datapackage-pipelines-aws-minio-test \
+    "-eMINIO_ACCESS_KEY=${AWS_ACCESS_KEY_ID}" \
+    "-eMINIO_SECRET_KEY=${AWS_SECRET_ACCESS_KEY}" \
+    minio/minio server /data &
+
+sleep 10
+
+rm tests/minio/pipeline-spec.yaml
+
+echo
+echo
+echo " > Review the generated data in http://localhost:9000"
+echo " > Stop the minio server when done - docker rm --force datapackage-pipelines-aws-minio-test"
+echo


### PR DESCRIPTION
Added support for setting S3_ENDPOINT_URL environment variable - which allows to use the library with S3 compatible apis

When this environment variable is set - I also enabled auto-creation of bucket if it doesn't exist. I think it's a more sensible default when using self hosted storage server - where bucket creation is cheap and fast.

Added a test which demonstrates using it with [minio](https://www.minio.io/)
