### PR TITLE
[change_acl][s]: handle the cases when folder contains more than 1000 items

### DIFF
--- a/datapackage_pipelines_aws/processors/change_acl.py
+++ b/datapackage_pipelines_aws/processors/change_acl.py
@@ -17,7 +17,7 @@ def change_acl():
     is_truncated = True
     contents = []
     marker = ''
-    # Consider that list_objects returns max 1000 keys (even if MaxKeys is >1000)
+    # list_objects returns max 1000 keys (even if MaxKeys is >1000)
     while is_truncated:
         try:
             objs = s3.list_objects(Bucket=bucket, Prefix=key, Marker=marker)

--- a/datapackage_pipelines_aws/processors/change_acl.py
+++ b/datapackage_pipelines_aws/processors/change_acl.py
@@ -15,21 +15,17 @@ def change_acl():
     acl = parameters['acl']
 
     is_truncated = True
-    contents = []
     marker = ''
     # list_objects returns max 1000 keys (even if MaxKeys is >1000)
     while is_truncated:
         try:
             objs = s3.list_objects(Bucket=bucket, Prefix=key, Marker=marker)
             is_truncated = objs.get('IsTruncated')
-            contents += objs.get('Contents', [])
-            if len(contents):
-                marker = contents[-1]['Key']
+            for obj in objs.get('Contents', []):
+                s3.put_object_acl(Bucket=bucket, Key=obj['Key'], ACL=acl)
+                marker = obj['Key']
         except Exception:
             is_truncated = False
-    keys = [content['Key'] for content in contents]
-    for obj in keys:
-        s3.put_object_acl(Bucket=bucket, Key=obj, ACL=acl)
 
 
 change_acl()

--- a/datapackage_pipelines_aws/processors/change_acl.py
+++ b/datapackage_pipelines_aws/processors/change_acl.py
@@ -26,7 +26,7 @@ def change_acl():
             if len(contents):
                 marker = contents[-1]['Key']
         except Exception:
-            listing = False
+            is_truncated = False
     keys = [content['Key'] for content in contents]
     for obj in keys:
         s3.put_object_acl(Bucket=bucket, Key=obj, ACL=acl)


### PR DESCRIPTION
This pull request fixes https://github.com/datahq/pm/issues/205

`Client.list_objects()` method in Boto3, we are using to list the objects in the specific folder on S3 returns max 1000 items per request. While the method gives the ability to set MaxKeys parameter it effects only if number is <1000 and still returns 1000 items if it is set to Eg 2000. To get the rest of them we should set Marker parameter for it and request another chunck. Form their docs:

> NextMarker (string) -- When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMaker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys.